### PR TITLE
close task detail on press 'p' || 't' ||  'esc'

### DIFF
--- a/app/cli.go
+++ b/app/cli.go
@@ -88,9 +88,11 @@ func setKeyboardShortcuts() *tview.Application {
 		switch unicode.ToLower(event.Rune()) {
 		case 'p':
 			app.SetFocus(projectPane)
+			contents.RemoveItem(taskDetailPane)
 			return nil
 		case 't':
 			app.SetFocus(taskPane)
+			contents.RemoveItem(taskDetailPane)
 			return nil
 		}
 

--- a/app/projects.go
+++ b/app/projects.go
@@ -135,6 +135,7 @@ func (pane *ProjectPane) activateProject(idx int) {
 	projectDetailPane.SetProject(pane.activeProject)
 	contents.AddItem(projectDetailPane, 25, 0, false)
 	app.SetFocus(taskPane)
+	contents.RemoveItem(taskDetailPane)
 }
 
 // RemoveActivateProject deletes the currently active project

--- a/app/task_detail.go
+++ b/app/task_detail.go
@@ -290,6 +290,7 @@ func (td *TaskDetailPane) handleShortcuts(event *tcell.EventKey) *tcell.EventKey
 	switch event.Key() {
 	case tcell.KeyEsc:
 		app.SetFocus(taskPane)
+		contents.RemoveItem(taskDetailPane)
 		return nil
 	case tcell.KeyDown:
 		td.taskDetailView.ScrollDown(1)

--- a/app/tasks.go
+++ b/app/tasks.go
@@ -177,6 +177,7 @@ func (pane *TaskPane) LoadDynamicList(logic string) {
 		sort.Slice(tasks, func(i, j int) bool { return tasks[i].ProjectID < tasks[j].ProjectID })
 		pane.SetList(tasks)
 		app.SetFocus(taskPane)
+		contents.RemoveItem(taskDetailPane)
 
 		statusBar.showForSeconds("[yellow] Displaying tasks of "+rangeDesc, 5)
 	}


### PR DESCRIPTION
When working with tasks, it happens that the name of the task is long enough and overlaps with the detailed information about the task.

https://user-images.githubusercontent.com/2886680/145378030-6282d44c-c775-4dab-858f-397955b04043.mp4

Implemented that when switching on the 'p' key || 't' || 'esc' closes the detailed information of the task and it seems to be more convenient.


https://user-images.githubusercontent.com/2886680/145378213-e78f27dd-577a-44c7-8141-79f0d657aca5.mp4



