### PR TITLE
task_detail: remove due date when string is empty

### DIFF
--- a/app/task_detail.go
+++ b/app/task_detail.go
@@ -104,8 +104,12 @@ func (td *TaskDetailPane) makeDateRow() *tview.Flex {
 		SetDoneFunc(func(key tcell.Key) {
 			switch key {
 			case tcell.KeyEnter:
-				date := parseDateInputOrCurrent(td.taskDate.GetText())
-				td.setTaskDate(date.Unix(), true)
+                if td.taskDate.GetText() != "" {
+                    date := parseDateInputOrCurrent(td.taskDate.GetText())
+                    td.setTaskDate(date.Unix(), true)
+                } else {
+                    td.setTaskDate(0, true)
+                }
 			case tcell.KeyEsc:
 				td.setTaskDate(td.task.DueDate, false)
 			}


### PR DESCRIPTION
When the due date input box is empty, this will no remove the due date from the task

fixes [#27]


